### PR TITLE
Fix go mod to skip crypto VULNERABILITY

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module golang.org/x/text
 require golang.org/x/tools v0.1.12 // tagx:ignore
 
 require (
-	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect tagx:ignore
+	golang.org/x/mod v0.7.0 // indirect tagx:ignore
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect tagx:ignore
 )
 


### PR DESCRIPTION
golang.org/x/crypto Improper Signature Verification VULNERABILITY
CWE-347
CVE-2020-9283
CVSS 8.6 HIGH
SNYK-GOLANG-GOLANGORGXCRYPTOSSH-551923
SCORE
601
Introduced through
github.com/rs/zerolog@v1.17.3-0.20200115210151-505b18daf2bb and golang.org/x/crypto@v0.3.0 Fixed in
golang.org/x/crypto@0.0.0-20200220183623-bac4c82f6975 Exploit maturity
MATURE
Show less detail 
Detailed paths
Introduced through:  github.com/rs/zerolog@v1.17.3-0.20200115210151-505b18daf2bb › golang.org/x/tools@v0.0.0-20190828213141-aed303cbaa74 › golang.org/x/net@v0.0.0-20190620200207-3b0461eec859 › golang.org/x/crypto@v0.0.0-20190308221718-c2843e01d9a2 Introduced throughgolang.org/x/crypto@v0.3.0 › golang.org/x/net@v0.2.0 › golang.org/x/text@v0.4.0 › golang.org/x/mod@v0.6.0-dev.0.20220419223038-86c51ed26bb4 › golang.org/x/tools@v0.0.0-20191119224855-298f0cb1881e › golang.org/x/net@v0.0.0-20190620200207-3b0461eec859 › golang.org/x/crypto@v0.0.0-20190308221718-c2843e01d9a2 Security information
Factors contributing to the scoring:
Snyk: CVSS 8.6 - High Severity

NVD: CVSS 7.5 - High Severity
Why are the scores different? Learn how Snyk evaluates vulnerability scores